### PR TITLE
WebExtensions版の国際化対応

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "extlib/webextensions-lib-options"]
 	path = extlib/webextensions-lib-options
 	url = https://github.com/piroor/webextensions-lib-options.git
+[submodule "extlib/webextensions-lib-l10n"]
+	path = extlib/webextensions-lib-l10n
+	url = https://github.com/piroor/webextensions-lib-l10n.git

--- a/locale/en-US/messages.dtd
+++ b/locale/en-US/messages.dtd
@@ -1,6 +1,6 @@
 <!ENTITY config.title "Reload on Idle Configuration">
 <!ENTITY config.general "General">
-<!ENTITY config.idleSeconds.before "Reload tab when idleded over">
+<!ENTITY config.idleSeconds.before "Reload tab when idled over">
 <!ENTITY config.idleSeconds.after  "seconds">
 <!ENTITY config.filter.caption "Filter for tabs to be reloaded (regular expression for URLs)">
 <!ENTITY config.filter.before "/">

--- a/webextensions/Makefile
+++ b/webextensions/Makefile
@@ -1,8 +1,11 @@
-xpi: common/Configs.js options/Options.js clean
-	zip -q -r -0 reload-on-idle-we.xpi *.json *.js common options background
+xpi: common/l10n.js common/Configs.js options/Options.js clean
+	zip -q -r -0 reload-on-idle-we.xpi *.json *.js common options _locales
 
 clean:
 	rm -f *.xpi
+
+common/l10n.js: extlib
+	cp -p ../extlib/webextensions-lib-l10n/l10n.js $@
 
 common/Configs.js: extlib
 	cp -p ../extlib/webextensions-lib-configs/Configs.js $@

--- a/webextensions/_locales/en/messages.json
+++ b/webextensions/_locales/en/messages.json
@@ -1,0 +1,17 @@
+{
+  "description": {
+    "message": "Reloads specified tabs on idle to reduce memory usage."
+  },
+  "config.idleSeconds.before": {"message": "Reload tab when idleded over"},
+  "config.idleSeconds.after": {"message":  "seconds"},
+  "config.filter.caption": {
+    "message": "Filter for tabs to be reloaded (regular expression for URLs)"
+  },
+  "config.reloadBusyTabs": {
+    "message": "Reload forcibly even if the tab is still loading"
+  },
+  "config.ignoreConfirmation": {
+    "message": "Reload forcibly even if there is any editing form data"
+  },
+  "config.debug": {"message": "Output logs to the browser console"}
+}

--- a/webextensions/_locales/en/messages.json
+++ b/webextensions/_locales/en/messages.json
@@ -2,7 +2,7 @@
   "description": {
     "message": "Reloads specified tabs on idle to reduce memory usage."
   },
-  "config.idleSeconds.before": {"message": "Reload tab when idleded over"},
+  "config.idleSeconds.before": {"message": "Reload tab when idled over"},
   "config.idleSeconds.after": {"message":  "seconds"},
   "config.filter.caption": {
     "message": "Filter for tabs to be reloaded (regular expression for URLs)"

--- a/webextensions/_locales/ja/messages.json
+++ b/webextensions/_locales/ja/messages.json
@@ -1,0 +1,17 @@
+{
+  "description": {
+    "message": "定期的にタブを再読み込みすることでメモリ消費を抑えます。"
+  },
+  "config.idleSeconds.before": {"message": ""},
+  "config.idleSeconds.after": {"message":  "秒以上操作されなかったらタブを再読み込みする"},
+  "config.filter.caption": {
+    "message": "再読み込みするページのフィルタ（URLにマッチする正規表現）"
+  },
+  "config.reloadBusyTabs": {
+    "message": "読み込みが完了していないタブでも強制的に再読み込みする"
+  },
+  "config.ignoreConfirmation": {
+    "message": "フォームに入力中のデータがあっても強制的に再読み込みする"
+  },
+  "config.debug": {"message": "ブラウザコンソールにログを出力する"}
+}

--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -2,7 +2,8 @@
   "manifest_version": 2,
   "name": "Reload on Idle (WE)",
   "version": "1.7",
-  "description": "Reloads specified tabs on idle to reduce memory usage.",
+  "description": "__MSG_description__",
+  "default_locale": "en",
 
   "permissions": [
     "alarms",

--- a/webextensions/options/options.html
+++ b/webextensions/options/options.html
@@ -7,6 +7,7 @@
     <meta charset="UTF-8">
     <script src="/common/Configs.js"></script>
     <script src="/common/common.js"></script>
+    <script src="/common/l10n.js"></script>
     <script src="/options/Options.js"></script>
     <script src="/options/init.js"></script>
     <link rel="stylesheet" type="text/css" href="options.css">
@@ -14,12 +15,13 @@
 
   <body>
     <p><label>
+      __MSG_config.idleSeconds.before__
       <input id="idleSeconds" type="number" min="15">
-      秒以上操作されなかったらタブを再読み込みする
+      __MSG_config.idleSeconds.after__
     </label></p>
 
     <label for='filter'>
-      再読み込みするページのフィルタ（URLにマッチする正規表現）
+      __MSG_config.filter.caption__
     </label>
 
     <div id='regexp'>
@@ -30,12 +32,12 @@
 
     <p><label>
       <input id="reloadBusyTabs" type="checkbox">
-      読み込みが完了していないタブでも強制的に再読み込みする
+      __MSG_config.reloadBusyTabs__
     </label>
 
     <p><label>
       <input id="debug" type="checkbox">
-      ブラウザコンソールにログを出力する
+      __MSG_config.debug__
     </label>
   </body>
 </html>


### PR DESCRIPTION
先週のプルリク #2 で残件となっていた項目の対応パッチです。

### 改修について

* 国際化対応にあたっては、既存のアドオン (`TreeStyleTab`) の仕組みを踏襲してます。
  * manifest.jsonの多言語化はWebExtensionsネイティブの機構を利用しています。
  * 設定ページの多言語化は `webextensions-lib-l10n` ライブラリを利用してます。
* 各言語のテキストはXPCOM版アドオンから引っ張ってきています。
  * 参照したファイルは locale/ ディレクトリ配下の messages.dtd です。

### スクリーンショット

実際に各環境で設定画面を表示すると次のようになりました：

*英語環境*

![roi_en_20170928](https://user-images.githubusercontent.com/8974561/30949029-0520152a-a44f-11e7-9aa9-89183a70f60a.png)

*日本語環境*

![roi_ja_20170928](https://user-images.githubusercontent.com/8974561/30949034-10af3fba-a44f-11e7-8f58-df173c53d25e.png)

