### PR TITLE
WE: Implement an option to ignore confirmation dialogs.

### DIFF
--- a/webextensions/common/common.js
+++ b/webextensions/common/common.js
@@ -26,5 +26,6 @@ configs = new Configs({
   idleSeconds: 600,
   filter: '.',
   reloadBusyTabs: false,
+  ignoreConfirmation: false,
   debug: false,
 });

--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -9,7 +9,8 @@
     "alarms",
     "idle",
     "tabs",
-    "storage"
+    "storage",
+    "<all_urls>"
   ],
 
   "options_ui": {

--- a/webextensions/options/options.html
+++ b/webextensions/options/options.html
@@ -36,6 +36,11 @@
     </label>
 
     <p><label>
+      <input id="ignoreConfirmation" type="checkbox">
+      __MSG_config.ignoreConfirmation__
+    </label>
+
+    <p><label>
       <input id="debug" type="checkbox">
       __MSG_config.debug__
     </label>


### PR DESCRIPTION
### What's this patch?

This patch provides an option to skip the "Do you really want to leave?" dialog for
WebExtensions environments.

### How it works

I've found that the confirmation dialog can be skipped (without any XPCOM tricks!)
by overriding the `beforeunload` callbacks.

Here is how it works:

 * The dialog is managed by the return value of `beforeunload` callbacks; If a non-
    empty string is returned, Firefox will display the dialog and halt reloading. 
 * So we can effectively suppress the dialog by attaching an additional callback just
   before calling `tabs.reload()` and overriding the return value to an empty string.

Note that DOM3 3.1 specifies:

> Next, the implementation must determine the current target's candidate event listeners. This must be the list of all event listeners that have been registered on the current target **in their order of registration.**

I confirmed this actually works in Mozilla Firefox 52.5.0 on Linux.